### PR TITLE
Add TrakHoundHttp Sink connector

### DIFF
--- a/DIME/Configs/main.yaml
+++ b/DIME/Configs/main.yaml
@@ -6,6 +6,7 @@ sinks:
   - *redisSink1
   - *shdrSink1
   - *sparkplugBSink1
+  - *trakhoundHttpSink1
 sources:
   - *ascCpcSource1
   - *eipSource1

--- a/DIME/Configs/trakhoundHttpSink1.yaml
+++ b/DIME/Configs/trakhoundHttpSink1.yaml
@@ -1,0 +1,10 @@
+trakhoundHttpSink1: &trakhoundHttpSink1
+  name: trakhoundHttpSink1
+  enabled: !!bool true
+  scan_interval: !!int 1000
+  connector: TrakHoundHttp
+  hostname: localhost
+  port: 8472
+  useSsl: false
+  router: default
+  basePath: Ladder99:/DIME/HttpSink

--- a/DIME/Configuration/TrakHoundHttp/ConnectorConfiguration.cs
+++ b/DIME/Configuration/TrakHoundHttp/ConnectorConfiguration.cs
@@ -1,0 +1,11 @@
+namespace DIME.Configuration.TrakHoundHttp;
+
+public sealed class ConnectorConfiguration : Configuration.ConnectorConfiguration<ConnectorItem>
+{
+    public string Hostname { get; set; }
+    public int Port { get; set; }
+    public bool UseSsl { get; set; }
+    public string HostPath { get; set; }
+    public string BasePath { get; set; }
+    public string Router { get; set; }
+}

--- a/DIME/Configuration/TrakHoundHttp/ConnectorItem.cs
+++ b/DIME/Configuration/TrakHoundHttp/ConnectorItem.cs
@@ -1,0 +1,5 @@
+namespace DIME.Configuration.TrakHoundHttp;
+
+public sealed class ConnectorItem : Configuration.ConnectorItem
+{
+}

--- a/DIME/Configurator/SinkConnectorFactory.cs
+++ b/DIME/Configurator/SinkConnectorFactory.cs
@@ -31,6 +31,9 @@ public static class SinkConnectorFactory
             case "sparkplugb":
                 connector = SparkplugB.Sink.Create(section, disruptor);
                 break;
+            case "trakhoundhttp":
+                connector = TrakHoundHttp.Sink.Create(section, disruptor);
+                break;
             default:
                 break;
         }

--- a/DIME/Configurator/TrakHoundHttp/Sink.cs
+++ b/DIME/Configurator/TrakHoundHttp/Sink.cs
@@ -1,0 +1,26 @@
+using DIME.Configuration.TrakHoundHttp;
+using DIME.Connectors;
+
+namespace DIME.Configurator.TrakHoundHttp;
+
+public static class Sink
+{
+    public static IConnector Create(Dictionary<object, object> section, Disruptor.Dsl.Disruptor<MessageBoxMessage> disruptor)
+    {
+        ConnectorConfiguration config = new();
+        config.ConnectorType = section.ContainsKey("connector") ? Convert.ToString(section["connector"]) : "TrakHoundHttp";
+        config.Direction = Configuration.ConnectorDirectionEnum.Sink;
+        config.Enabled = section.ContainsKey("enabled") ? Convert.ToBoolean(section["enabled"]) : true;
+        config.ScanIntervalMs = section.ContainsKey("scan_interval") ? Convert.ToInt32(section["scan_interval"]) : 1000;
+        config.Name = section.ContainsKey("name") ? Convert.ToString(section["name"]) : Guid.NewGuid().ToString();
+        config.Hostname = section.ContainsKey("hostname") ? Convert.ToString(section["hostname"]) : "localhost";
+        config.Port = section.ContainsKey("port") ? Convert.ToInt16(section["port"]) : 8472;
+        config.UseSsl = section.ContainsKey("useSsl") ? Convert.ToBoolean(section["useSsl"]) : false;
+        config.HostPath = section.ContainsKey("hostPath") ? Convert.ToString(section["hostPath"]) : null;
+        config.Router = section.ContainsKey("router") ? Convert.ToString(section["router"]) : null;
+        config.BasePath = section.ContainsKey("basePath") ? Convert.ToString(section["basePath"]) : null;
+        var connector = new Connectors.TrakHoundHttp.Sink(config, disruptor);
+
+        return connector;
+    }
+}

--- a/DIME/Connectors/TrakHoundHttp/Sink.cs
+++ b/DIME/Connectors/TrakHoundHttp/Sink.cs
@@ -1,0 +1,120 @@
+using DIME.Configuration.TrakHoundHttp;
+using TrakHound;
+using TrakHound.Clients;
+using TrakHound.Entities;
+using TrakHound.Requests;
+
+namespace DIME.Connectors.TrakHoundHttp;
+
+public class Sink: SinkConnector<ConnectorConfiguration, ConnectorItem>
+{
+    private readonly TrakHoundOnChangeFilter _filter;
+    private TrakHoundHttpPublishStreamClient _trakhoundClient;
+
+
+    public Sink(ConnectorConfiguration configuration, Disruptor.Dsl.Disruptor<MessageBoxMessage> disruptor) : base(configuration, disruptor)
+    {
+        _filter = new TrakHoundOnChangeFilter();
+    }
+
+    protected override bool InitializeImplementation()
+    {
+        _filter.Clear();
+        return true;
+    }
+
+    protected override bool CreateImplementation()
+    {
+        var clientConfiguration = new TrakHoundHttpClientConfiguration();
+        clientConfiguration.Hostname = Configuration.Hostname;
+        clientConfiguration.Port = Configuration.Port;
+        clientConfiguration.UseSSL = Configuration.UseSsl;
+        clientConfiguration.Path = Configuration.HostPath;
+
+        var routerId = Configuration.Router;
+
+        _trakhoundClient = new TrakHoundHttpPublishStreamClient(clientConfiguration, routerId);
+        return true;
+    }
+
+    protected override bool ConnectImplementation()
+    {
+        if (_trakhoundClient != null) _trakhoundClient.Connect();
+        return true;
+    }
+
+    protected override bool WriteImplementation()
+    { 
+        if (_trakhoundClient != null)
+        {
+            foreach (var message in Outbox)
+            {
+                if (!string.IsNullOrEmpty(message.Path) && message.Data != null)
+                {
+                    var value = message.Data.ToString(); // Need to take into account Arrays
+
+                    if (_filter.Filter(message.Path, value))
+                    {
+                        var observation = new TrakHoundObservationEntry();
+                        observation.ObjectPath = GetMessagePath(message.Path);
+                        observation.Value = value;
+                        observation.DataType = value.IsNumeric() ? TrakHoundObservationDataType.Double : TrakHoundObservationDataType.String;
+                        observation.Timestamp = UnixTimeExtensions.FromUnixTimeMilliseconds(message.Timestamp);
+
+                        _trakhoundClient.Publish(observation);
+                    }
+                }
+            }
+        }
+        
+        return true;
+    }
+
+    protected override bool DisconnectImplementation()
+    {
+        if (_trakhoundClient != null) _trakhoundClient.Disconnect();
+        return true;
+    }
+    
+    protected override bool DeinitializeImplementation()
+    {
+        if (_trakhoundClient != null) _trakhoundClient.Dispose();
+        return true;
+    }
+
+
+    private string GetMessagePath(string messagePath)
+    {
+        if (messagePath != null)
+        {
+            if (IsSystemMessage(messagePath))
+            {
+                return TrakHoundPath.Combine("Ladder99:/.DIME/ModuleSink", messagePath);
+            }
+            else
+            {
+                // Remove Module Name
+                var path = Url.RemoveFirstFragment(messagePath);
+
+                // Add BasePath from Configuration
+                if (!string.IsNullOrEmpty(Configuration.BasePath)) path = TrakHoundPath.Combine(Configuration.BasePath, path);
+
+                return path;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsSystemMessage(string messagePath)
+    {
+        if (messagePath != null)
+        {
+            var path = Url.RemoveFirstFragment(messagePath);
+            var name = Url.GetFirstFragment(path);
+            return name == "$SYSTEM";
+        }
+
+        return false;
+    }
+}

--- a/DIME/DIME.csproj
+++ b/DIME/DIME.csproj
@@ -35,6 +35,7 @@
       <PackageReference Include="StackExchange.Redis" Version="2.8.22" />
       <PackageReference Include="Topshelf" Version="4.3.0" />
       <PackageReference Include="Topshelf.NLog" Version="4.3.0" />
+      <PackageReference Include="TrakHound.Common" Version="0.1.6.6" />
       <PackageReference Include="YamlDotNet" Version="16.2.0" />
     </ItemGroup>
 
@@ -121,6 +122,9 @@
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
       <None Update="Configs\smartPacSource1.yaml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <None Update="Configs\trakhoundHttpSink1.yaml">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
     </ItemGroup>


### PR DESCRIPTION
# Overview
This adds the ability to publish to TrakHound using an HTTP websocket connection using the TrakHoundHttp Sink connector.

## Configuration
Parameters for connecting to a TrakHound Instance are set in the configuration. The "basePath" parameter can be used to specify where source data gets published to. The "router" parameter can be used to specify the TrakHound Router ID/Name to use when publishing data.
```yaml
trakhoundHttpSink1: &trakhoundHttpSink1
  name: trakhoundHttpSink1
  enabled: !!bool true
  scan_interval: !!int 1000
  connector: TrakHoundHttp
  hostname: localhost
  port: 8472
  useSsl: false
  router: default
  basePath: Ladder99:/DIME/HttpSink
```

## $SYSTEM Data
Currently any messages with the $SYSTEM prefix are published to the Hidden directory at "Ladder99:/.DIME".